### PR TITLE
fixed openvswitch bridge template

### DIFF
--- a/netif.d/bridge-openvswitch
+++ b/netif.d/bridge-openvswitch
@@ -2,7 +2,6 @@
 
 netif_depend() {
         need ovsdb-server
-        need ovs-controller
         need ovs-vswitchd
 }
 


### PR DESCRIPTION
ovs-controller does no longer exist and isn't anymore needed.