### PR TITLE
openvswitch and vlan

### DIFF
--- a/init.d/netif.tmpl
+++ b/init.d/netif.tmpl
@@ -73,7 +73,7 @@ debug() {
 depend() {
 	need localmount
 	if [ "$vlanmode" != "off" ]; then
-		if [ "${trunk#netif.}" != "${trunk}" ]; then
+		if [ "${trunk#netif.}" = "${trunk}" ]; then
 			#begins with netif
 			need "netif.${trunk}"
 		else
@@ -98,7 +98,7 @@ start() {
 		# attempt to silently load ipv6 module
 		modprobe -q ipv6
 	fi
-	if [ "$vlanmode" != "off" ]; then
+	if [ "$vlanmode" != "off" -a "$vlanmode" != "script" ]; then #configure vlan only if not managed by netif_* script
 		if [ ! -d /proc/net/vlan ]; then
 			modprobe -q 8021q
 			if [ ! -d /proc/net/vlan ]; then
@@ -145,7 +145,7 @@ stop() {
 	ip addr flush dev $interface scope global
 	netif_post_down
 	# VLANS:
-	[ "${vlanmode}" != "off" ] && ip link delete ${interface}
+	[ "${vlanmode}" != "off" -a "$vlanmode" != "script" ] && ip link delete ${interface}
 	netif_destroy
 	eend 0
 }
@@ -310,7 +310,7 @@ ezrule() {
 	fi
 }
 
-if [ -z "$trunk" ]; then
+if [ -z "$trunk" -a -z "$vlanmode" ]; then
 	# auto-detect trunk/vlan ID from interface name
 	vlanmode="auto"
 	vlan="${interface##*.}"
@@ -318,7 +318,7 @@ if [ -z "$trunk" ]; then
 	[ "$vlan" = "$interface" ] && vlanmode="off"
 else
 	# trunk/vlan ID specified by user in config
-	vlanmode="custom"
+	: ${vlanmode:="custom"} #don't overwrite vlanmode if already specified
 	require vlan
 fi
 

--- a/netif.d/bridge-openvswitch
+++ b/netif.d/bridge-openvswitch
@@ -1,58 +1,63 @@
 #!/bin/sh -x
 
 netif_depend() {
-        need ovsdb-server
-        need ovs-vswitchd
+	need ovsdb-server
+	need ovs-vswitchd
 }
 
 netif_create() {
-        ovs-vsctl --may-exist  add-br $interface
+	vlanmode="script"
+	if [ "$trunk" != "$interface" -a "$vlan" != "$interface" ]; then
+		ovs-vsctl --may-exist  add-br $interface $(get_interface_names $trunk) $vlan
+	else
+		ovs-vsctl --may-exist  add-br $interface
+	fi
 }
 
 netif_destroy() {
-        ovs-vsctl --if-exists del-br $interface
+	ovs-vsctl --if-exists del-br $interface
 }
 
 netif_pre_down() {
-        local slave
+	local slave
 
-        if [ -n "$slaves" ]; then
-                for slave in $(get_interface_names $slaves); do
-                        ovs-ofctl mod-port $interface ${slave} down
-                        ovs-vsctl --if-exists del-port $interface ${slave}
-                done
-        fi
+	if [ -n "$slaves" ]; then
+		for slave in $(get_interface_names $slaves); do
+			ovs-ofctl mod-port $interface ${slave} down
+			ovs-vsctl --if-exists del-port $interface ${slave}
+		done
+	fi
 
-        ovs-ofctl mod-port $interface $interface down
+	ovs-ofctl mod-port $interface $interface down 2>/dev/null
 }
 
 netif_pre_up() {
-        local slave
-        local bcast
-        if [ -n "$slaves" ]; then
-                for slave in $(get_interface_names $slaves); do
-                        ovs-vsctl --may-exist add-port $interface ${slave}
-                        ovs-ofctl mod-port $interface ${slave} up
-                done
-        fi
+	local slave
+	local bcast
+	if [ -n "$slaves" ]; then
+		for slave in $(get_interface_names $slaves); do
+			ovs-vsctl --may-exist add-port $interface ${slave}
+			ovs-ofctl mod-port $interface ${slave} up
+		done
+	fi
 
-        for ipnm in $ipaddr $ipaddrs; do
-            if [ -n "$(if_ipv4 $ipnm)" ]; then
-                bcast="broadcast $(get_option "$ipnm" broadcast +)"
-            else
-                bcast=""
-            fi
+	for ipnm in $ipaddr $ipaddrs; do
+		if [ -n "$(if_ipv4 $ipnm)" ]; then
+			bcast="broadcast $(get_option "$ipnm" broadcast +)"
+		else
+			bcast=""
+		fi
 
-            ip addr add $(get_ipnm_part "$ipnm") $bcast dev $interface || die "Couldn't add $ipnm to $interface"
-        done
+		ip addr add $(get_ipnm_part "$ipnm") $bcast dev $interface || die "Couldn't add $ipnm to $interface"
+	done
 
-        if [ -n "$stp" ]; then
-            ovs-vsctl --if-exists set bridge $interface stp_enable=true
-        fi
+	if [ -n "$stp" ]; then
+		ovs-vsctl --if-exists set bridge $interface stp_enable=true
+	fi
 
-        if [ -n "$forwarding" ]; then
-            /sbin/sysctl net.ipv4.conf.${interface}.forwarding=${forwarding} >/dev/null 2>&1
-        fi
+	if [ -n "$forwarding" ]; then
+		/sbin/sysctl net.ipv4.conf.${interface}.forwarding=${forwarding} >/dev/null 2>&1
+	fi
 
 }
 

--- a/netif.d/bridge-openvswitch
+++ b/netif.d/bridge-openvswitch
@@ -2,7 +2,6 @@
 
 netif_depend() {
         need ovsdb-server
-        need ovs-controller
         need ovs-vswitchd
 }
 


### PR DESCRIPTION
- openvswitch fake bridge vlan support
- ability to manage vlans by custom /etc/netif.d/* script by setting $vlanmode to "script" at netif_create()